### PR TITLE
Bugfix in data alignment and array count

### DIFF
--- a/Sources/CDRCodable/Decoder/CDRDecoder.swift
+++ b/Sources/CDRCodable/Decoder/CDRDecoder.swift
@@ -171,6 +171,7 @@ extension DataStore {
     func readArray<T>(_ type: T.Type) throws -> [T] where T: Numeric {
         let size = MemoryLayout<T>.size
         let count = try readCheckBlockCount(of: size)
+        align(to: MemoryLayout<T>.alignment)
         defer {
             cursor = cursor.advanced(by: count * size)
         }

--- a/Sources/CDRCodable/Encoder/CDREncoder.swift
+++ b/Sources/CDRCodable/Encoder/CDREncoder.swift
@@ -46,7 +46,6 @@ final public class CDREncoder {
             let encoder: _CDREncoder = _CDREncoder(data: dataStore)
             encoder.userInfo = self.userInfo
             try value.encode(to: encoder)
-            encoder.container?.closeContainer()    // finalize dataBlock changes.
         }
 
         // Final data aligment
@@ -66,7 +65,6 @@ protocol _CDREncodingContainer {
     var dataStore: _CDREncoder.DataStore { get }
     var codingPath: [CodingKey] { get set }
     func write(count: Int) throws
-    func closeContainer()
 }
 
 final class _CDREncoder {

--- a/Sources/CDRCodable/Encoder/KeyedEncodingContainer.swift
+++ b/Sources/CDRCodable/Encoder/KeyedEncodingContainer.swift
@@ -25,8 +25,9 @@ extension _CDREncoder {
 
 extension _CDREncoder.KeyedContainer: KeyedEncodingContainerProtocol {
     @inline(__always)
-    private func encodeNumericArray(count: Int, pointer: UnsafeRawBufferPointer) throws {
+    private func encodeNumericArray(alignment: Int, count: Int, pointer: UnsafeRawBufferPointer) throws {
         try write(count: count)
+        dataStore.align(alignment)
         dataStore.data.append(pointer.baseAddress!.assumingMemoryBound(to: UInt8.self), count: pointer.count)
     }
 
@@ -119,18 +120,18 @@ extension _CDREncoder.KeyedContainer: KeyedEncodingContainerProtocol {
             return
         }
         switch value {
-        case let value as [Int]: try encodeNumericArray(count: value.count, pointer: value.withUnsafeBytes{ $0 })
-        case let value as [Int8]: try encodeNumericArray(count: value.count, pointer: value.withUnsafeBytes{ $0 })
-        case let value as [Int16]: try encodeNumericArray(count: value.count, pointer: value.withUnsafeBytes{ $0 })
-        case let value as [Int32]: try encodeNumericArray(count: value.count, pointer: value.withUnsafeBytes{ $0 })
-        case let value as [Int64]: try encodeNumericArray(count: value.count, pointer: value.withUnsafeBytes{ $0 })
-        case let value as [UInt]: try encodeNumericArray(count: value.count, pointer: value.withUnsafeBytes{ $0 })
-        case let value as [UInt8]: try encodeNumericArray(count: value.count, pointer: value.withUnsafeBytes{ $0 })
-        case let value as [UInt16]: try encodeNumericArray(count: value.count, pointer: value.withUnsafeBytes{ $0 })
-        case let value as [UInt32]: try encodeNumericArray(count: value.count, pointer: value.withUnsafeBytes{ $0 })
-        case let value as [UInt64]: try encodeNumericArray(count: value.count, pointer: value.withUnsafeBytes{ $0 })
-        case let value as [Float]: try encodeNumericArray(count: value.count, pointer: value.withUnsafeBytes{ $0 })
-        case let value as [Double]: try encodeNumericArray(count: value.count, pointer: value.withUnsafeBytes{ $0 })
+        case let value as [Int]: try encodeNumericArray(alignment: MemoryLayout<Int>.alignment, count: value.count, pointer: value.withUnsafeBytes{ $0 })
+        case let value as [Int8]: try encodeNumericArray(alignment: MemoryLayout<Int8>.alignment, count: value.count, pointer: value.withUnsafeBytes{ $0 })
+        case let value as [Int16]: try encodeNumericArray(alignment: MemoryLayout<Int16>.alignment, count: value.count, pointer: value.withUnsafeBytes{ $0 })
+        case let value as [Int32]: try encodeNumericArray(alignment: MemoryLayout<Int32>.alignment, count: value.count, pointer: value.withUnsafeBytes{ $0 })
+        case let value as [Int64]: try encodeNumericArray(alignment: MemoryLayout<Int64>.alignment, count: value.count, pointer: value.withUnsafeBytes{ $0 })
+        case let value as [UInt]: try encodeNumericArray(alignment: MemoryLayout<UInt>.alignment, count: value.count, pointer: value.withUnsafeBytes{ $0 })
+        case let value as [UInt8]: try encodeNumericArray(alignment: MemoryLayout<UInt8>.alignment, count: value.count, pointer: value.withUnsafeBytes{ $0 })
+        case let value as [UInt16]: try encodeNumericArray(alignment: MemoryLayout<UInt16>.alignment, count: value.count, pointer: value.withUnsafeBytes{ $0 })
+        case let value as [UInt32]: try encodeNumericArray(alignment: MemoryLayout<UInt32>.alignment, count: value.count, pointer: value.withUnsafeBytes{ $0 })
+        case let value as [UInt64]: try encodeNumericArray(alignment: MemoryLayout<UInt64>.alignment, count: value.count, pointer: value.withUnsafeBytes{ $0 })
+        case let value as [Float]: try encodeNumericArray(alignment: MemoryLayout<Float>.alignment, count: value.count, pointer: value.withUnsafeBytes{ $0 })
+        case let value as [Double]: try encodeNumericArray(alignment: MemoryLayout<Double>.alignment, count: value.count, pointer: value.withUnsafeBytes{ $0 })
         case let value as Data:
             try write(count: value.count)
             dataStore.write(data: value)

--- a/Tests/CDRCodableTests/CDRCodableEncodingTests.swift
+++ b/Tests/CDRCodableTests/CDRCodableEncodingTests.swift
@@ -142,4 +142,22 @@ class CDRCodableEncodingTests: XCTestCase {
             0x01, 0, 0, 0, 0x02, 0, 0, 0,
             0x03, 0, 0, 0, 0x04, 0, 0, 0]))
     }
+
+    func testEncodeArrayOfStructWithAlignment() {
+        struct TestStruct: Codable {
+            let a: String
+            let b: [TestStruct2]
+        }
+        struct TestStruct2: Codable {
+            let a: Int32
+            let b: Int32
+        }
+        let value = TestStruct(a: "a", b: [TestStruct2(a: 1, b: 2), TestStruct2(a: 3, b: 4)])
+        let data = try! encoder.encode(value)
+        XCTAssertEqual(data, Data([
+            0x02, 0, 0, 0, 0x61, 0, 0, 0,
+            0x02, 0, 0, 0,
+            0x01, 0, 0, 0, 0x02, 0, 0, 0,
+            0x03, 0, 0, 0, 0x04, 0, 0, 0]))
+    }
 }

--- a/Tests/CDRCodableTests/CDRCodableEncodingTests.swift
+++ b/Tests/CDRCodableTests/CDRCodableEncodingTests.swift
@@ -71,4 +71,75 @@ class CDRCodableEncodingTests: XCTestCase {
         let data = try! encoder.encode(value)
         XCTAssertEqual(data, Data([0x55, 0, 0, 0, 0x0c, 0, 0, 0, 0x54, 0x65, 0x73, 0x74, 0x20, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0, 0x09, 0, 0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9, 0, 0, 0]))
     }
+
+    func testEncodeStructWithAlignment() {
+        struct TestStruct: Codable {
+            let a: Int8
+            let b: Int16
+            let c: Int16
+            let d: Int32
+            let e: Int64
+        }
+
+        let value = TestStruct(a: 1, b: 2, c: 3, d: 4, e: 5)
+        let data = try! encoder.encode(value)
+        XCTAssertEqual(data, Data([
+            0x01, 0, 0x02, 0, 0x03, 0, 0, 0,
+            0x04, 0, 0,    0, 0,    0, 0, 0,
+            0x05, 0, 0,    0, 0,    0, 0, 0]))
+    }
+
+    func testEncodeStructArrayWithoutAlignment() {
+        struct TestStruct: Codable {
+            let a: [Int8]
+            let b: [Int16]
+            let c: [Int16]
+            let d: [Int32]
+            let e: [Int64]
+        }
+
+        let value = TestStruct(a: [1, 1, 1, 1], b: [2, 2], c: [3, 3], d: [4, 4], e: [5])
+        let data = try! encoder.encode(value)
+        XCTAssertEqual(data, Data([
+            0x04, 0, 0, 0, 0x01, 0x01, 0x01, 0x01,
+            0x02, 0, 0, 0, 0x02, 0,    0x02, 0,
+            0x02, 0, 0, 0, 0x03, 0,    0x03, 0,
+            0x02, 0, 0, 0, 0x04, 0,    0,    0,
+            0x04, 0, 0, 0, 0x01, 0,    0,    0,
+            0x05, 0, 0, 0, 0,    0,    0,    0]))
+    }
+
+    func testEncodeStructArrayWithAlignment() {
+        struct TestStruct: Codable {
+            let a: [Int8]
+            let b: [Int16]
+            let c: [Int16]
+            let d: [Int32]
+            let e: [Int64]
+        }
+
+        let value = TestStruct(a: [1], b: [2], c: [3], d: [4], e: [5])
+        let data = try! encoder.encode(value)
+        XCTAssertEqual(data, Data([
+            0x01, 0, 0, 0, 0x01, 0, 0, 0,
+            0x01, 0, 0, 0, 0x02, 0, 0, 0,
+            0x01, 0, 0, 0, 0x03, 0, 0, 0,
+            0x01, 0, 0, 0, 0x04, 0, 0, 0,
+            0x01, 0, 0, 0, 0,    0, 0, 0,
+            0x05, 0, 0, 0, 0,    0, 0, 0]))
+    }
+
+    func testEncodeArrayOfStruct() {
+        struct TestStruct: Codable {
+            let a: Int32
+            let b: Int32
+        }
+
+        let value = [TestStruct(a: 1, b: 2), TestStruct(a: 3, b: 4)]
+        let data = try! encoder.encode(value)
+        XCTAssertEqual(data, Data([
+            0x02, 0, 0, 0,
+            0x01, 0, 0, 0, 0x02, 0, 0, 0,
+            0x03, 0, 0, 0, 0x04, 0, 0, 0]))
+    }
 }

--- a/Tests/CDRCodableTests/CDRCodableRoundTripTests.swift
+++ b/Tests/CDRCodableTests/CDRCodableRoundTripTests.swift
@@ -83,4 +83,30 @@ class CDRCodableRoundTripTests: XCTestCase {
         let dataBack = try! encoder.encode(value)
         XCTAssertEqual(dataBack, data)
     }
+
+    func testArrayOfStruct() {
+        struct Test: Codable, Equatable {
+            let a: Int32
+            let b: Int32
+        }
+        let example = [Test(a: 1, b: 2), Test(a: 3, b: 4)]
+        let data = try! encoder.encode(example)
+        let exampleBack = try! decoder.decode([Test].self, from: data)
+        XCTAssertEqual(example, exampleBack)
+    }
+
+    func testStructWithAlignment() {
+        struct TestStruct: Codable, Equatable {
+            let a: [Int8]
+            let b: [Int16]
+            let c: [Int16]
+            let d: [Int32]
+            let e: [Int64]
+        }
+
+        let example = TestStruct(a: [1], b: [2], c: [3], d: [4], e: [5])
+        let data = try! encoder.encode(example)
+        let exampleBack = try! decoder.decode(TestStruct.self, from: data)
+        XCTAssertEqual(example, exampleBack)
+    }
 }

--- a/Tests/CDRCodableTests/CDRCodableRoundTripTests.swift
+++ b/Tests/CDRCodableTests/CDRCodableRoundTripTests.swift
@@ -89,10 +89,13 @@ class CDRCodableRoundTripTests: XCTestCase {
             let a: Int32
             let b: Int32
         }
-        let example = [Test(a: 1, b: 2), Test(a: 3, b: 4)]
-        let data = try! encoder.encode(example)
-        let exampleBack = try! decoder.decode([Test].self, from: data)
-        XCTAssertEqual(example, exampleBack)
+        let data = Data([
+            0x02, 0, 0, 0,
+            0x01, 0, 0, 0, 0x02, 0, 0, 0,
+            0x03, 0, 0, 0, 0x04, 0, 0, 0])
+        let example = try! decoder.decode([Test].self, from: data)
+        let dataBack = try! encoder.encode(example)
+        XCTAssertEqual(data, dataBack)
     }
 
     func testStructWithAlignment() {
@@ -105,8 +108,36 @@ class CDRCodableRoundTripTests: XCTestCase {
         }
 
         let example = TestStruct(a: [1], b: [2], c: [3], d: [4], e: [5])
-        let data = try! encoder.encode(example)
-        let exampleBack = try! decoder.decode(TestStruct.self, from: data)
-        XCTAssertEqual(example, exampleBack)
+        do {
+            let data = try encoder.encode(example)
+            let exampleBack = try decoder.decode(TestStruct.self, from: data)
+            XCTAssertEqual(example, exampleBack)
+        } catch {
+            XCTFail()
+        }
+    }
+
+    func testNestedStructWithAlignment() {
+        struct TestStruct: Codable, Equatable {
+            let a: [Int8]
+            let b: [Int16]
+            let c: [Int16]
+            let d: [Int32]
+            let e: [Int64]
+        }
+        struct TestNestedStruct: Codable, Equatable {
+            let a: TestStruct
+            let b: TestStruct
+        }
+        let example = TestNestedStruct(
+            a: TestStruct(a: [1], b: [2], c: [3], d: [4], e: [5]),
+            b: TestStruct(a: [1], b: [2], c: [3], d: [4], e: [5]))
+        do {
+            let data = try encoder.encode(example)
+            let exampleBack = try decoder.decode(TestNestedStruct.self, from: data)
+            XCTAssertEqual(example, exampleBack)
+        } catch {
+            XCTFail()
+        }
     }
 }


### PR DESCRIPTION
Hello @DimaRU

This is great work to enable CDR in Swift!
I was lucky to find your very new work to serialize data for ROS2 with Swift!

I found some issues when I tried to utilize this for my project.
Here are the changes with this PR

- Additional test cases
  - Some of them fail with the current code (misalignment, array count)
  - Please check with the commit (313728b64bc4716cd1f836a475b537e077e47a7b)
- Fix: data alignment after array count for unbounded numeric arrays
  - misalignment can happen with the Int64 array because the data step is bigger than the array count (Int32)
- Fix: array count for other types
  - I am not sure why, but `encoder.container` can't keep `count` (container might be copied)
  - array size can be written after alignment, so the `index` should be obtained after writing the count

